### PR TITLE
Games now give hints for incorrect answers

### DIFF
--- a/elbow/games/game.py
+++ b/elbow/games/game.py
@@ -43,7 +43,7 @@ class Game(object):
         if guess == str(self.answer):
             return "Congratulations you win!"
         else:
-            return "Incorrect"
+            return "Incorrect\n%s" % self.give_hint(guess)
 
     # "Private" methods - inheriting classes shouldn't touch these
 

--- a/elbow/games/guess_my_number.py
+++ b/elbow/games/guess_my_number.py
@@ -15,7 +15,7 @@ class GuessMyNumber(Game):
         This function gives feedback to the player saying if their answer was too
         low or too high.
         """
-        if answer < self.answer:
+        if int(answer) < self.answer:
             return "Your guess was too low"
         else:
             return "Your guess was too high."


### PR DESCRIPTION
As stated in the title, if an incorrect answer is given then the guess is passed to a `give_hint` method in the `Game` class (or any inheriting classes). The default implementation of this function is just to return an empty string `""`. Any games which want to give hints/feedback to the player must override this function.

On another note - am I doing something wrong I seem to be generating merge commits left right and center?
